### PR TITLE
Add tile button variant and update ProductSelector

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: "default" | "ghost" | "subtle" | "danger" | "outline";
+  variant?: "default" | "ghost" | "subtle" | "danger" | "outline" | "tile";
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
@@ -16,7 +16,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       ghost: "bg-transparent text-black hover:bg-gray-100 border border-gray-300 focus:ring-gray-300",
       subtle: "bg-gray-100 text-gray-800 hover:bg-gray-200 border border-gray-300 focus:ring-gray-300",
       danger: "bg-red-100 text-red-700 hover:bg-red-200 border border-red-300 focus:ring-red-300",
-      outline: "bg-transparent text-gray-700 border border-gray-300 hover:bg-gray-50 focus:ring-gray-300"
+      outline: "bg-transparent text-gray-700 border border-gray-300 hover:bg-gray-50 focus:ring-gray-300",
+      tile: "bg-white text-gray-700 shadow hover:bg-gray-50 hover:shadow-md focus:ring-gray-300"
     };
 
     return (

--- a/src/pages/ProductSelector.tsx
+++ b/src/pages/ProductSelector.tsx
@@ -197,8 +197,8 @@ export default function ProductSelector() {
       key={item.name}
       onClick={() => handleSelect(item.name)}
       disabled={!isValidSelection(item.name)}
-      variant="outline"
-      className="flex flex-col items-center space-y-2 p-3 h-36 relative"
+      variant="tile"
+      className="flex flex-col items-center space-y-2 p-3 h-36 relative transition-shadow hover:shadow-md focus:shadow-md"
       onMouseLeave={() => setShowTooltipId(null)}
     >
       <div


### PR DESCRIPTION
## Summary
- add a `tile` variant to the Button component
- update ProductSelector to use the new `tile` variant for gift items
- give item buttons hover and focus shadow feedback

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7f5ace30832bb236945f8bd18a45