### PR TITLE
Update Button colors

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,13 +9,13 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant = "default", ...props }, ref) => {
     const baseClasses =
-      "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 px-4 py-2";
+      "inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50";
 
     const variantClasses = {
-      default: "bg-red-600 text-white hover:bg-red-700 focus:ring-red-500",
+      default: "bg-redCross text-white hover:bg-redCrossLight focus:ring-redCross",
       ghost: "bg-transparent text-black hover:bg-gray-100 border border-gray-300 focus:ring-gray-300",
       subtle: "bg-gray-100 text-gray-800 hover:bg-gray-200 border border-gray-300 focus:ring-gray-300",
-      danger: "bg-red-100 text-red-700 hover:bg-red-200 border border-red-300 focus:ring-red-300",
+      danger: "bg-red-100 text-redCross hover:bg-red-200 border border-red-300 focus:ring-redCross",
       outline: "bg-transparent text-gray-700 border border-gray-300 hover:bg-gray-50 focus:ring-gray-300"
     };
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,6 +7,7 @@ export default {
     extend: {
       colors: {
         redCross: '#d62828',
+        redCrossLight: '#e63946',
       },
       fontSize: {
         sm: '0.95rem',


### PR DESCRIPTION
## Summary
- use new `redCross` palette for button styling
- add `redCrossLight` helper color

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7f60104c832b89209106eff8ec68