### PR TITLE
Improve button variants and selection UI

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -3,16 +3,26 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: "default" | "ghost" | "subtle" | "danger" | "outline";
+  variant?:
+    | "default"
+    | "primary"
+    | "secondary"
+    | "ghost"
+    | "subtle"
+    | "danger"
+    | "outline";
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant = "default", ...props }, ref) => {
     const baseClasses =
-      "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 px-4 py-2";
+      "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 px-4 py-2 min-h-12";
 
     const variantClasses = {
-      default: "bg-red-600 text-white hover:bg-red-700 focus:ring-red-500",
+      default: "bg-redCross text-white hover:bg-red-700 focus:ring-redCross",
+      primary: "bg-redCross text-white hover:bg-red-700 focus:ring-redCross",
+      secondary:
+        "bg-gray-100 text-gray-800 hover:bg-gray-200 border border-gray-300 focus:ring-gray-300",
       ghost: "bg-transparent text-black hover:bg-gray-100 border border-gray-300 focus:ring-gray-300",
       subtle: "bg-gray-100 text-gray-800 hover:bg-gray-200 border border-gray-300 focus:ring-gray-300",
       danger: "bg-red-100 text-red-700 hover:bg-red-200 border border-red-300 focus:ring-red-300",

--- a/src/pages/ProductSelector.tsx
+++ b/src/pages/ProductSelector.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
+import { cn } from "@/lib/utils";
 import { X } from "lucide-react";
 import Spinner from "@/components/Spinner";
 import { createClient } from "@supabase/supabase-js";
@@ -192,15 +193,20 @@ export default function ProductSelector() {
 
   const canSubmit = selectedItems.length === 2 && userName.trim() !== "";
 
-  const renderItemCard = (item: GiftItem) => (
-    <Button
-      key={item.name}
-      onClick={() => handleSelect(item.name)}
-      disabled={!isValidSelection(item.name)}
-      variant="outline"
-      className="flex flex-col items-center space-y-2 p-3 h-36 relative"
-      onMouseLeave={() => setShowTooltipId(null)}
-    >
+  const renderItemCard = (item: GiftItem) => {
+    const isSelected = selectedItems.includes(item.name);
+    return (
+      <Button
+        key={item.name}
+        onClick={() => handleSelect(item.name)}
+        disabled={!isValidSelection(item.name)}
+        variant="outline"
+        className={cn(
+          "flex flex-col items-center space-y-2 p-3 h-36 relative",
+          isSelected && "border-redCross bg-red-50"
+        )}
+        onMouseLeave={() => setShowTooltipId(null)}
+      >
       <div
         className="relative w-full max-h-24 aspect-[2/1]"
         onTouchStart={() => setShowTooltipId(item.id)}
@@ -362,10 +368,10 @@ export default function ProductSelector() {
       </div>
 
       <div className="flex justify-between gap-4">
-        <Button onClick={handleReset} variant="subtle" className="w-1/2">
+        <Button onClick={handleReset} variant="secondary" className="w-1/2">
           초기화
         </Button>
-        <Button disabled={!canSubmit} onClick={handleSubmit} className="w-1/2">
+        <Button disabled={!canSubmit} onClick={handleSubmit} variant="primary" className="w-1/2">
           완료
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- add `primary` and `secondary` button variants
- highlight selected product cards
- use new variants in product selector
- enforce minimum button size for touch friendliness

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7f6a8e24832baf686035cff536d9