### PR TITLE
Fix syntax error in ProductSelector

### DIFF
--- a/src/pages/ProductSelector.tsx
+++ b/src/pages/ProductSelector.tsx
@@ -249,6 +249,7 @@ export default function ProductSelector() {
       </div>
     </Button>
   );
+  };
   
   return (
     <div className="max-w-2xl mx-auto p-6 space-y-8 relative">


### PR DESCRIPTION
## Summary
- fix the missing closing brace for `renderItemCard` in `ProductSelector.tsx`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d8417a85c832bbe62c1fab235ecc9