### PR TITLE
Add lazy loading to ProductSelector image

### DIFF
--- a/src/pages/ProductSelector.tsx
+++ b/src/pages/ProductSelector.tsx
@@ -216,6 +216,7 @@ export default function ProductSelector() {
           <img
             src={item.image_url}
             alt={item.name}
+            loading="lazy"
             className="w-full h-full object-contain rounded shadow-inner"
           />
         ) : (


### PR DESCRIPTION
## Summary
- improve initial load performance by lazy loading product selector images

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d853dd2b0832b9cb248a2a3d49cc0