### PR TITLE
Refine focus styles for accessibility

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -16,18 +16,18 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant = "default", ...props }, ref) => {
     const baseClasses =
-      "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 px-4 py-2 min-h-12";
+      "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 px-4 py-2 min-h-12";
 
     const variantClasses = {
-      default: "bg-redCross text-white hover:bg-red-700 focus:ring-redCross",
-      primary: "bg-redCross text-white hover:bg-red-700 focus:ring-redCross",
+      default: "bg-redCross text-white hover:bg-red-700 focus-visible:ring-redCross",
+      primary: "bg-redCross text-white hover:bg-red-700 focus-visible:ring-redCross",
       secondary:
-        "bg-gray-100 text-gray-800 hover:bg-gray-200 border border-gray-300 focus:ring-gray-300",
-      ghost: "bg-transparent text-black hover:bg-gray-100 border border-gray-300 focus:ring-gray-300",
-      subtle: "bg-gray-100 text-gray-800 hover:bg-gray-200 border border-gray-300 focus:ring-gray-300",
-      danger: "bg-red-100 text-redCross hover:bg-red-200 border border-red-300 focus:ring-redCross",
-      outline: "bg-transparent text-gray-700 border border-gray-300 hover:bg-gray-50 focus:ring-gray-300"
-      tile: "bg-white text-gray-700 shadow hover:bg-gray-50 hover:shadow-md focus:ring-gray-300"
+        "bg-gray-100 text-gray-800 hover:bg-gray-200 border border-gray-300 focus-visible:ring-gray-300",
+      ghost: "bg-transparent text-black hover:bg-gray-100 border border-gray-300 focus-visible:ring-gray-300",
+      subtle: "bg-gray-100 text-gray-800 hover:bg-gray-200 border border-gray-300 focus-visible:ring-gray-300",
+      danger: "bg-red-100 text-redCross hover:bg-red-200 border border-red-300 focus-visible:ring-redCross",
+      outline: "bg-transparent text-gray-700 border border-gray-300 hover:bg-gray-50 focus-visible:ring-gray-300"
+      tile: "bg-white text-gray-700 shadow hover:bg-gray-50 hover:shadow-md focus-visible:ring-gray-300"
     };
 
     return (

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, ...pr
     <input
       ref={ref}
       className={cn(
-        "flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-black placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-redCross disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-black placeholder:text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-redCross disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- make form controls show focus ring only on keyboard navigation

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d85856cc4832ba63e5505ccb77487