### PR TITLE
Fix ButtonProps variants

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -10,7 +10,8 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
     | "ghost"
     | "subtle"
     | "danger"
-    | "outline";
+    | "outline"
+    | "tile";
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(


### PR DESCRIPTION
## Summary
- add missing `tile` variant type for `<Button />`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d85b8ceec832bb1dec6468e453f34