### PR TITLE
Fix Button variant object syntax

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -27,7 +27,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       ghost: "bg-transparent text-black hover:bg-gray-100 border border-gray-300 focus-visible:ring-gray-300",
       subtle: "bg-gray-100 text-gray-800 hover:bg-gray-200 border border-gray-300 focus-visible:ring-gray-300",
       danger: "bg-red-100 text-redCross hover:bg-red-200 border border-red-300 focus-visible:ring-redCross",
-      outline: "bg-transparent text-gray-700 border border-gray-300 hover:bg-gray-50 focus-visible:ring-gray-300"
+      outline: "bg-transparent text-gray-700 border border-gray-300 hover:bg-gray-50 focus-visible:ring-gray-300",
       tile: "bg-white text-gray-700 shadow hover:bg-gray-50 hover:shadow-md focus-visible:ring-gray-300"
     };
 


### PR DESCRIPTION
## Summary
- fix missing comma in button variant classes

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d86d8ec24832b84691147ce512a0d