### PR TITLE
Limit product grid to 3 columns

### DIFF
--- a/src/pages/ProductSelector.tsx
+++ b/src/pages/ProductSelector.tsx
@@ -322,7 +322,7 @@ export default function ProductSelector() {
       <div>
         <h2 className="text-xl font-semibold text-gray-700 mb-3">A 품목</h2>
         {loadingGiftItems ? (
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-3 gap-4">
             {Array.from({ length: 4 }).map((_, idx) => (
               <div
                 key={idx}
@@ -331,14 +331,14 @@ export default function ProductSelector() {
             ))}
           </div>
         ) : (
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">{aItems.map(renderItemCard)}</div>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-3 gap-4">{aItems.map(renderItemCard)}</div>
         )}
       </div>
 
       <div>
         <h2 className="text-xl font-semibold text-gray-700 mb-3">B 품목</h2>
         {loadingGiftItems ? (
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-3 gap-4">
             {Array.from({ length: 4 }).map((_, idx) => (
               <div
                 key={idx}
@@ -347,7 +347,7 @@ export default function ProductSelector() {
             ))}
           </div>
         ) : (
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">{bItems.map(renderItemCard)}</div>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-3 gap-4">{bItems.map(renderItemCard)}</div>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- ensure product grids never exceed three columns on wide screens

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d899150c4832bb611d87deee6648b