### PR TITLE
Add deploy timestamp to workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Build project
         run: npm run build
 
+      - name: Add timestamp
+        run: echo "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" > ./dist/.deploy-time
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
## Summary
- add a step before deploying that writes a timestamp file

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f8d4e09dc832bae5432d52bde25ea